### PR TITLE
Rename allocation info function for consistency

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -30,7 +30,7 @@ macro_rules! jemalloc_stat_value {
 }
 
 #[rustler::nif]
-pub fn allocation_info() -> NifResult<JemallocStats> {
+pub fn jemalloc_allocation_info() -> NifResult<JemallocStats> {
     jemalloc_ctl::epoch::mib().and_then(|x| x.advance()).ok();
 
     Ok(JemallocStats {


### PR DESCRIPTION
Making the function name consistency across rust and elixir makes usage
from other libraries or services much easier after the rustler 0.22
upgrade, which makes it harder to re-export other rust nifs under
different names (i.e., it's easier to export
`jemalloc_info::jemalloc_allocation_info` in the rustler init than
`jemalloc_info::allocation_info as foo`).