### PR TITLE
Bump rustler version

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,4 +10,4 @@ readme = "../README.md"
 
 [dependencies]
 jemalloc-ctl = "0.5.0"
-rustler = "0.25.0"
+rustler = "0.30.0"


### PR DESCRIPTION
sorted_set_nif can't compile in OTP 26 (https://github.com/discord/sorted_set_nif/issues/30), to fix this it should bump it's rustler version, but to be able to do that this lib must also bump it's version of rustler and then release a new version