### PR TITLE
update to rustler 0.37.x

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,4 +10,4 @@ readme = "../README.md"
 
 [dependencies]
 jemalloc-ctl = "0.5.0"
-rustler = "0.31.0"
+rustler = "0.37.0"


### PR DESCRIPTION
This updates `rustler` to 0.37.0.

Note that the primary elixir app does not actually depend on Rustler (it just provides a mixin that defines the struct and function interface), so the elixir component of this hasn't been modified.